### PR TITLE
Remove monkey patching to avoid race conditions

### DIFF
--- a/shepherd/manage.py
+++ b/shepherd/manage.py
@@ -1,5 +1,3 @@
-from gevent import monkey; monkey.patch_all(sys=True, Event=True)
-
 import sys
 import logging
 


### PR DESCRIPTION
Yielding (probably in minio) during http calls and I/O causes some ugly race conditions in `is_job_done` and maybe some other places.